### PR TITLE
fixed HeadersAlreadySentException

### DIFF
--- a/src/services/HtmlcacheService.php
+++ b/src/services/HtmlcacheService.php
@@ -251,7 +251,7 @@ class HtmlcacheService extends Component
             unlink($file);
             return false;
         }
-        echo file_get_contents($file);
+        \Yii::$app->response->data = file_get_contents($file);
     }
 
 }


### PR DESCRIPTION
When using devmode, im getting a HeadersAlreadySent exception from Yii. This seems to fix it.

Alternatively, setting \Yii::$app->response->isSent to true before echoing the output will also work.