### PR TITLE
Fix for cache duration setting being ignored

### DIFF
--- a/src/services/HtmlcacheService.php
+++ b/src/services/HtmlcacheService.php
@@ -247,8 +247,8 @@ class HtmlcacheService extends Component
      */
     private function loadCache($file)
     {
-        if (file_exists($settingsFile = $this->getDirectory() . 'settings.json')) {
-            $settings = json_decode(file_get_contents($settingsFile), true);
+        if (!empty($this->settings->cacheDuration)) {
+            $settings = ['cacheDuration' => $this->settings->cacheDuration];
         } else {
             $settings = ['cacheDuration' => 3600];
         }

--- a/src/services/HtmlcacheService.php
+++ b/src/services/HtmlcacheService.php
@@ -247,7 +247,9 @@ class HtmlcacheService extends Component
      */
     private function loadCache($file)
     {
-        if (!empty($this->settings->cacheDuration)) {
+        if (file_exists($settingsFile = $this->getDirectory() . 'settings.json')) {
+            $settings = json_decode(file_get_contents($settingsFile), true);
+        } elseif (!empty($this->settings->cacheDuration)) {
             $settings = ['cacheDuration' => $this->settings->cacheDuration];
         } else {
             $settings = ['cacheDuration' => 3600];


### PR DESCRIPTION
I can't find any record of settings.json being created/used elsewhere