### PR TITLE
Skip cache if Ajax request

### DIFF
--- a/src/services/HtmlcacheService.php
+++ b/src/services/HtmlcacheService.php
@@ -106,8 +106,12 @@ class HtmlcacheService extends Component
         if (\Craft::$app->request->getIsLivePreview()) {
             return false;
         }
-        // Skip if it's a post/ajax request
+        // Skip if it's a post request
         if (!\Craft::$app->request->getIsGet()) {
+            return false;
+        }
+        // Skip if it's an ajax request
+        if (\Craft::$app->request->getIsAjax()) {
             return false;
         }
         // Skip if route from element api


### PR DESCRIPTION
Previously it was assumed an ajax request was a POST but you could be GET'ing via ajax (to get live content and skip out the html cache).