### PR TITLE
add feature for excluding URL paths

### DIFF
--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -19,6 +19,7 @@ class Settings extends \craft\base\Model
     public $optimizeContent = 0;
     public $cacheDuration = 3600;
     public $purgeCache = 0;
+    public $excludedUrlPaths = [];
 
     public function rules() {
         return [

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -19,7 +19,6 @@ class Settings extends \craft\base\Model
     public $optimizeContent = 0;
     public $cacheDuration = 3600;
     public $purgeCache = 0;
-    public $excludedEntries = [];
 
     public function rules() {
         return [

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -19,6 +19,7 @@ class Settings extends \craft\base\Model
     public $optimizeContent = 0;
     public $cacheDuration = 3600;
     public $purgeCache = 0;
+    public $excludedEntries = [];
 
     public function rules() {
         return [

--- a/src/services/HtmlcacheService.php
+++ b/src/services/HtmlcacheService.php
@@ -166,7 +166,7 @@ class HtmlcacheService extends Component
             $siteId = intval(next($exclude));
 
             // check if requested path is one of those of the settings
-            if ($requestedPath == $path || preg_match('/' . $path . '/', $requestedPath)) {
+            if ($requestedPath == $path || preg_match('@' . $path . '@', $requestedPath)) {
                 // and if requested site either corresponds to the exclude setting or if it's unimportant at all
                 if ($requestedSiteId == $siteId || $siteId < 0) {
                     return true;

--- a/src/services/HtmlcacheService.php
+++ b/src/services/HtmlcacheService.php
@@ -55,7 +55,7 @@ class HtmlcacheService extends Component
             return;
         }
         $cacheEntry = HtmlCacheCache::findOne(['uri' => $this->uri, 'siteId' => $this->siteId]);
-        
+
         // check if cache exists
         if ($cacheEntry) {
             $file = $this->getCacheFileName($cacheEntry->uid);
@@ -86,7 +86,7 @@ class HtmlcacheService extends Component
         if ($this->settings->enableGeneral == false) {
             return false;
         }
-        
+
         // Skip if system is not on and not in force mode
         if (!\Craft::$app->getIsSystemOn() && $this->settings->forceOn == false) {
             return false;
@@ -118,6 +118,11 @@ class HtmlcacheService extends Component
         if ($this->isElementApiRoute()) {
             return false;
         }
+        // Skip if currently requested URL path is excluded
+        if ($this->isPathExcluded()) {
+            return false;
+        }
+
         return true;
     }
 
@@ -141,6 +146,34 @@ class HtmlcacheService extends Component
                 }
             }
         }
+        return false;
+    }
+
+    /**
+     * Check if currently requested URL path has been added to list of excluded paths
+     *
+     * @return bool
+     */
+    private function isPathExcluded()
+    {
+        // determine currently requested URL path and the multi-site ID
+        $requestedPath = \Craft::$app->request->getFullPath();
+        $requestedSiteId = \Craft::$app->getSites()->getCurrentSite()->id;
+
+        // compare with excluded paths and sites from the settings
+        foreach ($this->settings->excludedUrlPaths as $exclude) {
+            $path = reset($exclude);
+            $siteId = intval(next($exclude));
+
+            // check if requested path is one of those of the settings
+            if ($requestedPath == $path) {
+                // and if requested site either corresponds to the exclude setting or if it's unimportant at all
+                if ($requestedSiteId == $siteId || $siteId < 0) {
+                    return true;
+                }
+            }
+        }
+
         return false;
     }
 

--- a/src/services/HtmlcacheService.php
+++ b/src/services/HtmlcacheService.php
@@ -166,7 +166,7 @@ class HtmlcacheService extends Component
             $siteId = intval(next($exclude));
 
             // check if requested path is one of those of the settings
-            if ($requestedPath == $path) {
+            if ($requestedPath == $path || preg_match('/' . $path . '/', $requestedPath)) {
                 // and if requested site either corresponds to the exclude setting or if it's unimportant at all
                 if ($requestedSiteId == $siteId || $siteId < 0) {
                     return true;

--- a/src/templates/_settings.twig
+++ b/src/templates/_settings.twig
@@ -52,3 +52,14 @@
     instructions: "Purge all current cached files" | t,
     on:           0,
 }) }}
+
+{{ forms.elementSelectField({
+    label:          'Excluded entries' | t,
+    instructions:   'Entries to be excluded from being cached' | t,
+    selectionLabel: 'Add to excludes' | t,
+    name:           'excludedEntries',
+    id:             'excludedEntries',
+    elementType:    'craft\\elements\\Entry',
+    elements:       settings.excludedEntries is not empty ? craft.entries().id(settings.excludedEntries).status(null).all() : null,
+    errors:         settings.getErrors('excludedEntries')
+}) }}

--- a/src/templates/_settings.twig
+++ b/src/templates/_settings.twig
@@ -52,3 +52,37 @@
     instructions: "Purge all current cached files" | t,
     on:           0,
 }) }}
+
+{% set siteOptions = [{
+    label: 'All sites' | t,
+    value: '-1',
+}] %}
+{% for site in craft.app.sites.allSites() %}
+    {% set siteOptions = siteOptions | merge([{
+        label: site.name,
+        value: site.id,
+    }]) %}
+{% endfor %}
+
+{{ forms.editableTableField({
+    label:          'Excluded URL paths' | t,
+    instructions:   'Paths to be excluded from being cached' | t,
+    name:           'excludedUrlPaths',
+    id:             'excludedUrlPaths',
+    cols:           [
+                        {
+                            heading: 'Excluded paths' | t,
+                            info: 'Enter URL paths without the <span class="code">siteURL</span> part as they are returned by <span class="code">\Craft::$app->request->getFullPath()</span>, like "any/page" insteadof "https://example.com/site-specific/path/any/page".' | t,
+                            type: 'singleline',
+                            placeholder: 'path/to/excluded/page',
+                        },
+                        {
+                            heading: 'Multi-site' | t,
+                            info: 'Choose either if the configured path shall always be excluded from caches regardless of which multi-site is requested or if the exclusion of given path is dependant on the requested site.' | t,
+                            type: 'select',
+                            options: siteOptions,
+                        },
+                    ],
+    rows:           settings.excludedUrlPaths,
+    errors:         settings.getErrors('excludedUrlPaths')
+}) }}

--- a/src/templates/_settings.twig
+++ b/src/templates/_settings.twig
@@ -59,7 +59,7 @@
 }] %}
 {% for site in craft.app.sites.allSites() %}
     {% set siteOptions = siteOptions | merge([{
-        label: site.name,
+        label: site.name ~ ' (' ~ site.language ~ ')',
         value: site.id,
     }]) %}
 {% endfor %}

--- a/src/templates/_settings.twig
+++ b/src/templates/_settings.twig
@@ -66,15 +66,15 @@
 
 {{ forms.editableTableField({
     label:          'Excluded URL paths' | t,
-    instructions:   'Paths to be excluded from being cached' | t,
+    instructions:   'Paths to be excluded from being cached, feel free to enter regular expressions as well as precise URL paths.' | t,
     name:           'excludedUrlPaths',
     id:             'excludedUrlPaths',
     cols:           [
                         {
                             heading: 'Excluded paths' | t,
-                            info: 'Enter URL paths without the <span class="code">siteURL</span> part as they are returned by <span class="code">\Craft::$app->request->getFullPath()</span>, like "any/page" insteadof "https://example.com/site-specific/path/any/page".' | t,
+                            info: 'Enter precise URL paths or regular expressions without the <span class="code">siteURL</span> part as they are returned by <span class="code">\Craft::$app->request->getFullPath()</span>, like "any/page" insteadof "https://example.com/site-specific/path/any/page".' | t,
                             type: 'singleline',
-                            placeholder: 'path/to/excluded/page',
+                            placeholder: 'path/to/excluded/page OR regex like path/.*/excluded/.*',
                         },
                         {
                             heading: 'Multi-site' | t,

--- a/src/templates/_settings.twig
+++ b/src/templates/_settings.twig
@@ -52,14 +52,3 @@
     instructions: "Purge all current cached files" | t,
     on:           0,
 }) }}
-
-{{ forms.elementSelectField({
-    label:          'Excluded entries' | t,
-    instructions:   'Entries to be excluded from being cached' | t,
-    selectionLabel: 'Add to excludes' | t,
-    name:           'excludedEntries',
-    id:             'excludedEntries',
-    elementType:    'craft\\elements\\Entry',
-    elements:       settings.excludedEntries is not empty ? craft.entries().id(settings.excludedEntries).status(null).all() : null,
-    errors:         settings.getErrors('excludedEntries')
-}) }}


### PR DESCRIPTION
This pull request contains a new setting in the plugin's settings panel. It's a table field which you can add URL paths with. These URL paths will then be excluded from being cached. Also, this works for multi-site applications as well, because the new table field in the settings has a dropdown to select which multi-site each path (each table row) has to be related to (by default you even can select "all sites" in case of the multi-site is unimportant). … Just see the diff to see what happens in detail.

Best wishes
Arvid