### PR TITLE
Added options to disable draft preview caching

### DIFF
--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -18,12 +18,13 @@ class Settings extends \craft\base\Model
     public $forceOn = 0;
     public $optimizeContent = 0;
     public $cacheDuration = 3600;
-    public $purgeCache = 0;
+	public $purgeCache = 0;
+	public $disablePreviewCache = 1;
     public $excludedUrlPaths = [];
 
     public function rules() {
         return [
-            [ ['enableGeneral', 'forceOn', 'optimizeContent', 'purgeCache' ], 'boolean' ],
+            [ ['enableGeneral', 'forceOn', 'optimizeContent', 'purgeCache', 'disablePreviewCache' ], 'boolean' ],
             [ ['cacheDuration' ], 'integer' ],
         ];
     }

--- a/src/services/HtmlcacheService.php
+++ b/src/services/HtmlcacheService.php
@@ -77,6 +77,10 @@ class HtmlcacheService extends Component
      */
     public function canCreateCacheFile()
     {
+		// Skip if it's a preview url
+		if ($this->settings->disablePreviewCache && Craft::$app->request->getIsPreview()) {
+			return false;
+		}
         // Skip if we're running in devMode and not in force mode
         if (\Craft::$app->config->general->devMode === true && $this->settings->forceOn == false) {
             return false;
@@ -109,11 +113,15 @@ class HtmlcacheService extends Component
         // Skip if it's a post request
         if (!\Craft::$app->request->getIsGet()) {
             return false;
-        }
+		}
+
         // Skip if it's an ajax request
         if (\Craft::$app->request->getIsAjax()) {
             return false;
-        }
+		}
+		
+		
+
         // Skip if route from element api
         if ($this->isElementApiRoute()) {
             return false;

--- a/src/templates/_settings.twig
+++ b/src/templates/_settings.twig
@@ -46,6 +46,15 @@
 }) }}
 
 {{ forms.lightswitchField({
+    label:        "Disable Preview Cache" | t,
+    id:           'disablePreviewCache',
+    name:         'disablePreviewCache',
+    instructions: "Disable the caching of a preview url, this prevents a draft from being publicly accessible" | t,
+    errors:       settings.getErrors('disablePreviewCache'),
+    on:           settings.disablePreviewCache
+}) }}
+
+{{ forms.lightswitchField({
     label:        "Purge Cache now?" | t,
     id:           'purgeCache',
     name:         'purgeCache',


### PR DESCRIPTION
Drafts preview url were being cached and that created unwanted draft to be publicly accessible. I added a settings to toggle caching of those urls