### PR TITLE
changed cache identifier from param to internal uri

### DIFF
--- a/src/HtmlCache.php
+++ b/src/HtmlCache.php
@@ -142,10 +142,14 @@ class HtmlCache extends Plugin
                 if ($this->htmlcacheService->canCreateCacheFile()) {
                     $elementClass = get_class($event->element);
                     if (!in_array($elementClass, [User::class, GlobalSet::class])) {
-                        $uri = \Craft::$app->request->getParam('p', '');
+                        $uri = \Craft::$app->request->getPathInfo() ?: $event->element->uri;
                         $siteId = \Craft::$app->getSites()->getCurrentSite()->id;
                         $elementId = $event->element->id;
-                        
+
+                        if (!$uri || strlen($uri) === 0) {
+                            return;
+                        }
+
                         // check if cache entry already exits otherwise create it
                         $cacheEntry = HtmlCacheCache::findOne(['uri' => $uri, 'siteId' => $siteId]);
                         if (!$cacheEntry) {

--- a/src/services/HtmlcacheService.php
+++ b/src/services/HtmlcacheService.php
@@ -38,7 +38,7 @@ class HtmlcacheService extends Component
      */
     public function __construct()
     {
-        $this->uri = \Craft::$app->request->getParam('p', '');
+        $this->uri = \Craft::$app->request->getPathInfo() ?: '__HOME__';
         $this->siteId = \Craft::$app->getSites()->getCurrentSite()->id;
         $this->settings = HtmlCache::getInstance()->getSettings();
     }


### PR DESCRIPTION
On newer Craft CMS Version you cant rely und the »p« parameter in the request. The provided .htaccess is still using that, but its dependent on apache. 

For example: On this often used nginx configuration the »p« parameter will not be used.
https://github.com/nystudio107/nginx-craft/blob/master/sites-available/somedomain.com.conf

In my fix i changed the uri recognition